### PR TITLE
feat: add auth & asterium routes with validations

### DIFF
--- a/src/controllers/asterium.controller.ts
+++ b/src/controllers/asterium.controller.ts
@@ -13,7 +13,7 @@ export async function createDiscovery(req: any, res: any) {
   const body = req.body;
   const row = await Asterium.create({
     ...body,
-    author_id: req.user!.sub,
+    author_id: Number(req.user!.sub),
     published_at: body.status === 'published' ? new Date() : null,
   });
   res.status(201).json(row);
@@ -24,7 +24,7 @@ export async function updateDiscovery(req: any, res: any) {
   const row = await Asterium.findByPk(Number(id));
   if (!row) return res.status(404).json({ error: 'No encontrado' });
 
-  if (req.user!.role !== 'admin' && row.author_id !== req.user!.sub) {
+  if (req.user!.role !== 'admin' && row.author_id !== Number(req.user!.sub)) {
     return res.status(403).json({ error: 'Sin permisos' });
   }
 
@@ -38,7 +38,7 @@ export async function deleteDiscovery(req: any, res: any) {
   const row = await Asterium.findByPk(Number(id));
   if (!row) return res.status(404).json({ error: 'No encontrado' });
 
-  if (req.user!.role !== 'admin' && row.author_id !== req.user!.sub) {
+  if (req.user!.role !== 'admin' && row.author_id !== Number(req.user!.sub)) {
     return res.status(403).json({ error: 'Sin permisos' });
   }
 

--- a/src/models/Asterium.ts
+++ b/src/models/Asterium.ts
@@ -49,5 +49,11 @@ Asterium.init(
     created_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
     updated_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
   },
-  { sequelize, tableName: 'asteriums', timestamps: false }
+  {
+  sequelize,
+  tableName: "asteriums",
+  timestamps: true,
+  createdAt: "created_at",
+  updatedAt: "updated_at",
+}
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -47,5 +47,11 @@ User.init(
     created_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
     updated_at: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
   },
-  { sequelize, tableName: 'users', timestamps: false }
+  {
+    sequelize,
+    tableName: "users",
+    timestamps: true, // Sequelize añadirá createdAt y updatedAt
+    createdAt: "created_at", // usa tus nombres de columnas
+    updatedAt: "updated_at",
+  }
 );

--- a/src/routes/asterium.routes.ts
+++ b/src/routes/asterium.routes.ts
@@ -13,9 +13,13 @@ asteriumRouter.get("/", asteriumController.listPublished);
 asteriumRouter.post("/", requireAuth, validate(createDiscoverySchema), asteriumController.createDiscovery);
 
 // Actualizar un descubrimiento
-asteriumRouter.put("/:id", requireAuth, validate(idParamSchema), validate(updateDiscoverySchema), asteriumController.updateDiscovery);
+asteriumRouter.put("/:id", requireAuth,
+  validate(idParamSchema, "params"),   // 👈 valida el parámetro de la URL
+  validate(updateDiscoverySchema, "body"), // 👈 valida el body
+  asteriumController.updateDiscovery
+);
 
 // Eliminar un descubrimiento
-asteriumRouter.delete("/:id", requireAuth, validate(idParamSchema), asteriumController.deleteDiscovery);
+asteriumRouter.delete("/:id", requireAuth, validate(idParamSchema, "params"), asteriumController.deleteDiscovery);
 
 export default asteriumRouter;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -12,7 +12,7 @@ authRouter.post("/register", validate(registerSchema), authController.register);
 // Login de usuario
 authRouter.post("/login", validate(loginSchema), authController.login);
 
-// Bonus: promover a admin (solo un admin puede hacerlo)
+// Esto es Bonus: promover a admin (solo un admin puede hacerlo)
 authRouter.put("/promote/:id", requireAuth, requireAdmin, authController.promoteToAdmin);
 
 export default authRouter;

--- a/src/schemas/asterium.schema.ts
+++ b/src/schemas/asterium.schema.ts
@@ -35,5 +35,5 @@ export const updateDiscoverySchema = z.object({
 
 // Validación de params
 export const idParamSchema = z.object({
-  id: z.string().regex(/^\d+$/, "El id debe ser un número entero"),
+  id: z.coerce.number().int().positive("El id debe ser un número positivo"),
 });


### PR DESCRIPTION
Se añadieron rutas de auth (registro, login, promover a admin).

Se añadieron rutas de asterium (listar, crear, actualizar, eliminar).

Validaciones con Zod en body y params.

Middleware validate mejorado para soportar diferentes fuentes.

Fix de permisos: solo admin o autor puede editar/eliminar.

Probado en Postman: todas las operaciones funcionan correctamente.